### PR TITLE
print to stderr

### DIFF
--- a/connectors/mcap/bin/mcap-record
+++ b/connectors/mcap/bin/mcap-record
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import sys
 import json
 import time
 import atexit
@@ -331,7 +332,7 @@ def run(session: zenoh.Session, args: argparse.Namespace):
                 if to_print:
                     print(
                         "==== Average frequencies of received data over last 10 s ====")
-                    print("\n".join(to_print))
+                    print("\n".join(to_print), file=sys.stderr)
 
             message_counter.clear()  # Reset counts after logging
 


### PR DESCRIPTION
To avoid buffering of stdout when run inside a docker container