### PR TITLE
Fix docker image run for live view

### DIFF
--- a/connectors/foxglove/bin/foxglove-liveview
+++ b/connectors/foxglove/bin/foxglove-liveview
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import time
 import json

--- a/requirements_connectors.txt
+++ b/requirements_connectors.txt
@@ -2,3 +2,4 @@
 -r connectors/mcap/requirements.txt
 -r connectors/mediamtx/requirements.txt
 -r connectors/mockups/requirements.txt
+-r connectors/foxglove/requirements.txt

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keelson-js",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "main": "index.js",
   "files": [

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -19,7 +19,7 @@ def read(fname):
 
 setup(
     name="keelson",
-    version="0.4.2",
+    version="0.4.3",
     license="Apache License 2.0",
     description="A python Software Development Kit for keelson",
     long_description=read("README.md"),


### PR DESCRIPTION
 sudo docker run --rm --network host  --name mcap-logger --volume /mnt/e/wsl/:/rec ghcr.io/rise-maritime/keelson:0.4.3-pre.1 "foxglove-liveview -k rise/@v0/ssrs18/**"

preped for relese 0.4.3
